### PR TITLE
Update dragon-directory.js to render Pre-K grade

### DIFF
--- a/dragon-directory.js
+++ b/dragon-directory.js
@@ -6,7 +6,7 @@ import { html, render } from 'https://unpkg.com/htm/preact/standalone.module.js'
 const pre_k_grade = "0";
 
 // Map grade to value that can be compared and rendered
-function normalize_grade(grade) {
+function normalize_pre_k_grade(grade) {
   // The Pre-K grade is represented as the value 6, which is greater than
   // grade 5 (5th Grade). Mapping this to a value (0) that is less than
   // all the grades 1-5 means it can be sorted in a simple fashion.
@@ -134,7 +134,7 @@ function extract_students(record) {
       record[`Student #${i} Name (Last)`],
       record[`Student #${i} Name (Suffix)`],
     ].filter((x) => x.trim() !== "").join(' ').trim();
-      const grade = normalize_grade(record[`Student #${i} Grade Level`].trim());
+      const grade = normalize_pre_k_grade(record[`Student #${i} Grade Level`].trim());
       const teacher = record[`Student #${i} Teacher`].trim();
       if (student_name !== "") {
         students.push({ student_name, grade, teacher, neighborhood_school, bus_route, in_dragon_directory, orig_entry_date, orig_entry_date  });

--- a/dragon-directory.js
+++ b/dragon-directory.js
@@ -5,6 +5,26 @@ import { html, render } from 'https://unpkg.com/htm/preact/standalone.module.js'
 
 const pre_k_grade = "0";
 
+// Map grade to value that can be compared and rendered
+function normalize_grade(grade) {
+  // The Pre-K grade is represented as the value 6, which is greater than
+  // grade 5 (5th Grade). Mapping this to a value (0) that is less than
+  // all the grades 1-5 means it can be sorted in a simple fashion.
+  const pre_k_grade_value = "6";
+  if (pre_k_grade_value === grade) {
+    return pre_k_grade;
+  }
+  return grade;
+}
+
+// Turn grade string into display value
+function render_grade(grade) {
+  if (pre_k_grade === grade) {
+    return "Pre-K";
+  }
+  return "Grade " + grade;
+}
+
 // A record can contain up to 4 parent/guardian information sets.
 //
 // The entry for parents is structured as follows:
@@ -114,7 +134,7 @@ function extract_students(record) {
       record[`Student #${i} Name (Last)`],
       record[`Student #${i} Name (Suffix)`],
     ].filter((x) => x.trim() !== "").join(' ').trim();
-      const grade = record[`Student #${i} Grade Level`].trim();
+      const grade = normalize_grade(record[`Student #${i} Grade Level`].trim());
       const teacher = record[`Student #${i} Teacher`].trim();
       if (student_name !== "") {
         students.push({ student_name, grade, teacher, neighborhood_school, bus_route, in_dragon_directory, orig_entry_date, orig_entry_date  });
@@ -122,23 +142,6 @@ function extract_students(record) {
   }
 
   return students;
-}
-
-// Map grade to value that can be compared and rendered
-function normalize_grade(grade) {
-  const pre_k_grade_value = "6";
-  if (pre_k_grade_value === grade) {
-    return pre_k_grade;
-  }
-  return grade;
-}
-
-// Turn grade string into display value
-function render_grade(grade) {
-  if (pre_k_grade === grade) {
-    return "Pre-K";
-  }
-  return "Grade " + grade;
 }
 
 // Turns record into an array of student objects.

--- a/dragon-directory.js
+++ b/dragon-directory.js
@@ -3,6 +3,7 @@ import jsPDF from 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/+esm'
 
 import { html, render } from 'https://unpkg.com/htm/preact/standalone.module.js'
 
+const pre_k_grade = "0";
 
 // A record can contain up to 4 parent/guardian information sets.
 //
@@ -121,6 +122,23 @@ function extract_students(record) {
   }
 
   return students;
+}
+
+// Map grade to value that can be compared and rendered
+function normalize_grade(grade) {
+  const pre_k_grade_value = "6";
+  if (pre_k_grade_value === grade) {
+    return pre_k_grade;
+  }
+  return grade;
+}
+
+// Turn grade string into display value
+function render_grade(grade) {
+  if (pre_k_grade === grade) {
+    return "Pre-K";
+  }
+  return "Grade " + grade;
 }
 
 // Turns record into an array of student objects.
@@ -260,7 +278,7 @@ function renderStudents(raw_csv) {
 
       return (html`
           <section class="teacher-card">
-            <header class="teacher">${v[0].teacher} - Grade ${v[0].grade}</header>
+            <header class="teacher">${v[0].teacher} - ${render_grade(v[0].grade)}</header>
             <ul class="classlist">
               ${v.map(student => {
                   if (student.in_dragon_directory) {


### PR DESCRIPTION
Pre-K is represented with the value '6'.

Map this to 0 so that it can be sorted before 1st Grade.

Render the string as 'Pre-K' instead of 'Grade ' + number.